### PR TITLE
Update esp32-hal-uart.c

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -149,9 +149,9 @@ bool uartIsDriverInstalled(uart_t* uart)
 // Negative Pin Number will keep it unmodified, thus this function can set individual pins
 bool uartSetPins(uart_t* uart, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin)
 {
-    if(uart == NULL) {
-        return false;
-    }
+    if(uart == NULL) {      // overtake in Release !
+        return false;       // overtake in Release !
+    }                       // overtake in Release !
     UART_MUTEX_LOCK();
     // IDF uart_set_pin() will issue necessary Error Message and take care of all GPIO Number validation.
     bool retCode = uart_set_pin(uart->num, txPin, rxPin, rtsPin, ctsPin) == ESP_OK; 


### PR DESCRIPTION
Hi,

when will the change be added to the official repository?
In the current core package, this is still the outdated version and generates a critical warning.
I cannot create a pull request in the current blob. Hence the comment in the release candidate.
https://github.com/arduino/arduino-esp32/blob/arduino_nano_esp32/cores/esp32/esp32-hal-uart.c
```
/home/user/.arduino15/packages/arduino/hardware/esp32/2.0.13/cores/esp32/esp32-hal-uart.c: In function 'uartSetPins':
/home/user/.arduino15/packages/arduino/hardware/esp32/2.0.13/cores/esp32/esp32-hal-uart.c:153:9: warning: 'return' with no value, in function returning non-void
         return;
         ^~~~~~
/home/user/.arduino15/packages/arduino/hardware/esp32/2.0.13/cores/esp32/esp32-hal-uart.c:149:6: note: declared here
 bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin)
      ^~~~~~~~~~~
```