### PR TITLE
New (2nd try) partition table for UNO R4 WiFi

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1094,6 +1094,8 @@ arduino_unor4wifi_usb_bridge.serial.disableRTS=false
 
 arduino_unor4wifi_usb_bridge.build.tarch=xtensa
 arduino_unor4wifi_usb_bridge.build.bootloader_addr=0x0
+arduino_unor4wifi_usb_bridge.build.boot_app0_addr=0x9000
+arduino_unor4wifi_usb_bridge.build.app0_addr=0x50000
 arduino_unor4wifi_usb_bridge.build.target=esp32s3
 arduino_unor4wifi_usb_bridge.build.mcu=esp32s3
 arduino_unor4wifi_usb_bridge.build.core=esp32

--- a/platform.txt
+++ b/platform.txt
@@ -142,6 +142,8 @@ build.flash_freq=80m
 build.boot=qio
 build.boot_freq={build.flash_freq}
 build.bootloader_addr=0x1000
+build.boot_app0_addr=0xe000
+build.app0_addr=0x10000
 build.custom_bootloader=bootloader
 build.custom_partitions=partitions
 build.code_debug=0
@@ -265,7 +267,7 @@ debug.server.openocd.script=debug.cfg
 tools.esptool_py.upload.protocol=serial
 tools.esptool_py.upload.params.verbose=
 tools.esptool_py.upload.params.quiet=
-tools.esptool_py.upload.pattern_args=--chip {build.mcu} --port "{serial.port}" --baud {upload.speed} {upload.flags} --before default_reset --after hard_reset write_flash {upload.erase_cmd} -z --flash_mode {build.flash_mode} --flash_freq {build.flash_freq} --flash_size {build.flash_size} {build.bootloader_addr} "{build.path}/{build.project_name}.bootloader.bin" 0x8000 "{build.path}/{build.project_name}.partitions.bin" 0xe000 "{runtime.platform.path}/tools/partitions/boot_app0.bin" 0x10000 "{build.path}/{build.project_name}.bin" {upload.extra_flags}
+tools.esptool_py.upload.pattern_args=--chip {build.mcu} --port "{serial.port}" --baud {upload.speed} {upload.flags} --before default_reset --after hard_reset write_flash {upload.erase_cmd} -z --flash_mode {build.flash_mode} --flash_freq {build.flash_freq} --flash_size {build.flash_size} {build.bootloader_addr} "{build.path}/{build.project_name}.bootloader.bin" 0x8000 "{build.path}/{build.project_name}.partitions.bin" {build.boot_app0_addr} "{runtime.platform.path}/tools/partitions/boot_app0.bin" {build.app0_addr} "{build.path}/{build.project_name}.bin" {upload.extra_flags}
 tools.esptool_py.upload.pattern="{path}/{cmd}" {upload.pattern_args}
 tools.esptool_py.upload.pattern.linux=python3 "{path}/{cmd}" {upload.pattern_args}
 
@@ -273,7 +275,7 @@ tools.esptool_py.upload.pattern.linux=python3 "{path}/{cmd}" {upload.pattern_arg
 ## -------------------
 tools.esptool_py.program.params.verbose=
 tools.esptool_py.program.params.quiet=
-tools.esptool_py.program.pattern_args=--chip {build.mcu} --port "{serial.port}" --baud {upload.speed} {upload.flags} --before default_reset --after hard_reset write_flash -z --flash_mode {build.flash_mode} --flash_freq {build.flash_freq} --flash_size {build.flash_size} 0x10000 "{build.path}/{build.project_name}.bin"
+tools.esptool_py.program.pattern_args=--chip {build.mcu} --port "{serial.port}" --baud {upload.speed} {upload.flags} --before default_reset --after hard_reset write_flash -z --flash_mode {build.flash_mode} --flash_freq {build.flash_freq} --flash_size {build.flash_size} {build.bootloader_addr} "{build.path}/{build.project_name}.bin"
 tools.esptool_py.program.pattern="{path}/{cmd}" {program.pattern_args}
 tools.esptool_py.program.pattern.linux=python3 "{path}/{cmd}" {program.pattern_args}
 

--- a/tools/partitions/unor4wifi.csv
+++ b/tools/partitions/unor4wifi.csv
@@ -1,9 +1,7 @@
 # Name,   Type, SubType,   Offset,  Size, Flags
-fws,      data, nvs,       0x9000,  0x005000,
-otadata,  data, ota,       0xe000,  0x002000,
-cert,     data, undefined, 0x10000, 0x040000,
+otadata,  data, ota,       0x9000,  0x002000,
+cert,     data, undefined, 0xB000,  0x045000,
 app0,     app,  ota_0,     0x50000, 0x190000,
 app1,     app,  ota_1,     0x1E0000,0x190000,
 spiffs,   data, spiffs,    0x370000,0x080000,
-nvs,      data, nvs,       0x3F0000,0x005000,
-coredump, data, coredump,  0x3F5000,0x00B000,
+nvs,      data, nvs,       0x3F0000,0x010000,


### PR DESCRIPTION
    - Remove fws partition
    - Increase certs partition using fws (thius would allow to load cactr_all.pem + custom certs)
    - Fix load address for app and boot_app binaries
    - Remove coredump and increase nvs